### PR TITLE
Point Source with PSF fitting

### DIFF
--- a/AstropyTab.py
+++ b/AstropyTab.py
@@ -1,0 +1,62 @@
+from astropy.table import Table
+from matplotlib import pyplot as plt
+
+plt.ion()
+
+class AstropyTab:
+    """Utility class for reading and working with Astropy tables """
+    def __init__(self, astrotab, array='a1100',inphot=False):
+        """
+        Creating a AstropyTab object will read in the astropy table.
+        Inputs:
+           catFile (astropy.table.Table) - astropy table
+           array (string) - one of 'a1100' (default), 'a1400', or 'a2000'
+           inphot (bool) - if the astropy table has the input known sources defined, i.e., if the photometry has been done from a SimuInputSources object. 
+           False by default. 
+        """
+        self.astrotab=astrotab
+        self.array = array
+        self.inphot=inphot
+
+
+
+    def plotInPhot(self):
+        """
+        Plots the comparison between the input known flux and that 
+        estimated from the observation. 
+        """
+        if self.inphot==False:
+            print('This table has not known input fluxes, so comparison between input fluxes and observed fluxes can not be done.')
+            
+        else:
+            plt.figure()
+            plt.errorbar(self.astrotab['flux_'+self.array+'_input'],self.astrotab['flux_fit'],yerr=self.astrotab['flux_unc'],fmt='.',color='black',ecolor='grey',elinewidth=0.5)
+            plt.plot(self.astrotab['flux_'+self.array+'_input'],self.astrotab['flux_'+self.array+'_input'],color='black')
+            plt.title(self.array,fontsize=18)
+            plt.xlabel('$F_{\\rm{in}}$[mJy]',fontsize=18)
+            plt.ylabel('$F_{\\rm{obs}}$[mJy]',fontsize=18)
+            plt.ylim(min(self.astrotab['flux_fit']*0.8),max(self.astrotab['flux_fit']*1.2))
+
+    def plotInPhotGroup(self):
+        """
+        Plots the comparison between the input known flux and that 
+        estimated from the observation, grouped when elements from 
+        the input catalog are not spatially resolved.
+        """
+        if self.inphot==False:
+            print('This table has not known input fluxes, so comparison between input fluxes and observed fluxes can not be done.')
+            
+        else:
+            plt.figure()
+            plt.errorbar(self.astrotab['flux_'+self.array+'_input_group'],self.astrotab['flux_fit_group'],yerr=self.astrotab['flux_unc_group'],fmt='.',color='black',ecolor='grey',elinewidth=0.5)
+            plt.plot(self.astrotab['flux_'+self.array+'_input_group'],self.astrotab['flux_'+self.array+'_input_group'],color='black')
+            plt.title(self.array+' Grouped',fontsize=18)
+            plt.xlabel('$F_{\\rm{in}}$[mJy]',fontsize=18)
+            plt.ylabel('$F_{\\rm{obs}}$[mJy]',fontsize=18)
+            plt.ylim(min(self.astrotab['flux_fit_group']*0.8),max(self.astrotab['flux_fit_group']*1.2))
+            
+            
+            
+            
+            
+        

--- a/README.md
+++ b/README.md
@@ -27,25 +27,42 @@ work.
 This is a helper class for reading in and reformatting PyBDSF catalogs.  This
 is much less sophisticated than ToltecSignalFits.py but I find it useful all
 the same.  The class pulls data from the ...srl.FITS file in the catalog directory
-of the pyBdsf reduction.
+of the pyBdsf reduction. This class can be combined with ToltecSignalFits class to extract 
+point source photometry using PSF fitting
  
 Usage Example:
 ```
   from BdsfCat import BdsfCat
   pb = BdsfCat(<path to srl.FITS file>)
+  tab_phot,index_weight=tf1p1.photPS(pb)
+  #index_weight returns where in the BdsfCat (pb) the weight in the signal is above that 
+  set in the TolTecSignalFits class
+  
+  
+  
 ```
 
 #### SimuInputSources.py
 
 This is a helper class for reading in and reformatting the simu input source lists
 that are used by tolteca simu to populate point sources in simulated maps.
+This class has a method (inphotPS) to perform PSF photometry at the input sources 
+coordinates using a ToltecSignalFits object. Once inphotPS is used, one can 
+plot the comparison between input and observed fluxes.
 
 Usage Example:
 ```
   from SimuInputSources import SumuInputSources
-  fluxLimit = 0.2     #in mJy
+  fluxLimit = 1.0     #in mJy
   sq = SimuInputSources(sourceFile, fluxLimit=fluxLimit)
+  inputtab_phot=sq.inphotPS(tf1p1)
+  inputtab_phot.plotInPhot()
+  
 ```
+
+
+
+
 
 #### CatalogMatch.py
 
@@ -76,6 +93,13 @@ paths to point them someplace useful.
 This is a script that uses pyBdsf to identify sources. This will generate a
 catalog that the scripts above can read and use.  I don't have pyBdsf installed
 on my laptop so I just run this script on Unity.
+
+#### AstropyTab.py
+
+This is a helper class for reading in and comparing fluxes from 
+an astropy table.
+
+
 
 ### How to Contribute
 

--- a/SimuInputSources.py
+++ b/SimuInputSources.py
@@ -4,7 +4,7 @@ import astropy.units as u
 import numpy as np
 import csv
 import os
-
+from AstropyTab import AstropyTab
 
 class inputSource:
     def __init__(self, name, ra, dec, f1p1, f1p4, f2p0, coords):
@@ -82,3 +82,38 @@ class SimuInputSources:
         self.decs = [s.dec for s in self.sources]
         self.coords = SkyCoord([s.coords for s in self.sources])
 
+####Method to perform photometry on input catalog with known fluxes 
+    def inphotPS(self,tfipj):
+        """Performs Point Source photometry from an input catalog of known fluxes (SimuInputSources object) in a ToltecSignalFits object (tfipj).
+        Inputs:
+         - tfipj [ToltecSignalFits class], the reduced fits file obtained from citlali already read as a ToltecSignalFits. 
+        Outputs:
+         - phot_tab. AstropyTab. AstropyTab object which contains an astropy table with the psf photometry results, i.e., fluxes estimations, uncertainties, and the input fluxes from the SimuInputSources
+        """        
+  
+
+        astropytab,index_weights=tfipj.photPS(self,xy_fixed=False,inphot=True)
+        phot_tab=astropytab.astrotab
+        
+        if tfipj.array=='a1100':
+         phot_tab['flux_'+tfipj.array+'_input']=np.array(self.f1p1)[index_weights[0]][phot_tab['id']-1]
+        elif  tfipj.array=='a1400':
+         phot_tab['flux_'+tfipj.array+'_input']=np.array(self.f1p4)[index_weights[0]][phot_tab['id']-1]
+        elif  tfipj.array=='a2000':
+         phot_tab['flux_'+tfipj.array+'_input']=np.array(self.f2p0)[index_weights[0]][phot_tab['id']-1]   
+         
+        phot_tab['flux_fit_group'] = np.empty(len(phot_tab))
+        phot_tab['flux_unc_group'] = np.empty(len(phot_tab))
+        phot_tab['flux_'+tfipj.array+'_input_group'] = np.empty(len(phot_tab))
+        groupsid=list(set(phot_tab['group_id'])) 
+        #flux_in=np.empty(len(groupsid))
+        #flux_out=np.empty(len(groupsid))
+        #flux_out_err=np.empty(len(groupsid))
+        for i in groupsid: 
+          flux_in=np.sum(phot_tab['flux_'+tfipj.array+'_input'][np.where(phot_tab['group_id']==i)])
+          flux_out=np.sum(phot_tab['flux_fit'][np.where(phot_tab['group_id']==i)])
+          flux_out_err=np.sum(phot_tab['flux_unc'][np.where(phot_tab['group_id']==i)])
+          phot_tab['flux_'+tfipj.array+'_input_group'][np.where(phot_tab['group_id']==i)]=flux_in
+          phot_tab['flux_fit_group'][np.where(phot_tab['group_id']==i)]=flux_out
+          phot_tab['flux_unc_group'][np.where(phot_tab['group_id']==i)]=flux_out_err         
+        return AstropyTab(phot_tab,inphot=True)


### PR DESCRIPTION
Added methods to perform PSF photometry to an input catalog, as well to a pybdsf catalog. Input and observed fluxes can be ploted for input catalogs combined with toltec reduced fits images. README.md has been change to include these new methods and classes.